### PR TITLE
g4: bluetooth: set soc name to rome

### DIFF
--- a/system_prop.mk
+++ b/system_prop.mk
@@ -31,6 +31,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # Bluetooth
 PRODUCT_PROPERTY_OVERRIDES += \
     bluetooth.chip.vendor=brcm \
+    qcom.bluetooth.soc=rome \
     ro.bt.bdaddr_path="/data/misc/bluetooth/bdaddr" \
     persist.service.avrcp.browsing=1
 


### PR DESCRIPTION
default = MCT hal
rome = H4 hal

G4 needs H4 hal!

https://github.com/CyanogenMod/android_system_bt/blob/staging/cm-14.0/hci/src/hci_hal.c#L34

Change-Id: I86a477f176bdf0755fc018bfcc26d6c60285c5cc